### PR TITLE
Updated Child feature to use 'birthday' instead of 'age'

### DIFF
--- a/backend/models/user_models.py
+++ b/backend/models/user_models.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, Field, HttpUrl, EmailStr, field_validator
+from pydantic import BaseModel, Field, HttpUrl, EmailStr, field_validator, model_validator
 # from models.interaction_models import Review, Notification, Activity, Event
 from typing import List, Optional, TYPE_CHECKING
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 if TYPE_CHECKING:
    from models.interaction_models import Notification, Event, Review
@@ -29,8 +29,8 @@ class User(BaseModel):
     children: List["Child"] = Field(default_factory=list)  # Default to empty list
     enrolledEvents: List["Event"] = Field(default_factory=list)
 
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=datetime.now(timezone.utc))
+    updatedAt: datetime = Field(default_factory=datetime.now(timezone.utc))
     notifications: Optional[List["Notification"]] = Field(default_factory=list)
     reviews: Optional[List["Review"]] = Field(default_factory=list)
 
@@ -54,22 +54,21 @@ class Child(BaseModel):
   firstName: str = Field(min_length=1, max_length=50)
   lastName: str = Field(min_length=1, max_length=50)
   homeschool: bool = Field(default_factory=False)
-  age: int = Field(ge=10)
+  birthday: datetime = Field(description="Child's date of birth", default_factory=datetime.now(timezone.utc))
 
   parents: Optional[List["User"]] = Field(default_factory=list)
   enrolledEvents: List["Event"] = Field(default_factory=list)
 
-  created_at: datetime = Field(default_factory=datetime.utcnow)
-  updated_at: datetime = Field(default_factory=datetime.utcnow)
+  createdAt: datetime = Field(default_factory=datetime.now(timezone.utc))
+  updatedAt: datetime = Field(default_factory=datetime.now(timezone.utc))
 
 class ChildCreate(BaseModel):
   firstName: str = Field(min_length=1, max_length=50)
   lastName: str = Field(min_length=1, max_length=50)
   homeschool: bool = False
-  age: int = Field(ge=10)
-  createdAt: datetime = Field(default_factory=datetime.utcnow)
-  updatedAt: datetime = Field(default_factory=datetime.utcnow)
-
+  birthday: datetime = Field(description="Child's date of birth", default_factory=datetime.now(timezone.utc))
+  createdAt: datetime = Field(default_factory=datetime.now(timezone.utc))
+  updatedAt: datetime = Field(default_factory=datetime.now(timezone.utc))
 
 class ChildUpdate(BaseModel):
   firstName: Optional[str] = Field(min_length=1, max_length=50)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -37,8 +37,6 @@ model Users {
   // One-to-m
   notifications     Notifications[]
   reviews           Reviews[]
-
-
 }
 
 enum Roles {
@@ -61,7 +59,7 @@ model Children {
   firstName             String
   lastName              String
   homeschool            Boolean
-  age                   Int
+  birthday              DateTime
 
   parentIDs String[] @db.ObjectId
   parents   Users[]   @relation(fields: [parentIDs], references: [id])

--- a/backend/routers/child.py
+++ b/backend/routers/child.py
@@ -33,7 +33,7 @@ async def create_child(
                 "firstName": child_data.firstName,
                 "lastName": child_data.lastName,
                 "homeschool": child_data.homeschool,
-                "age": child_data.age,
+                "birthday": child_data.birthday,
                 "parentIDs": [current_user.id], # Add the current user's ID to parentIDs
                 "eventIDs": [], # Create activityIDs array so we can easily add to it later
                 "createdAt": child_data.createdAt,


### PR DESCRIPTION
I have updated our **Child** feature to use birthday (date) instead of age.  I've also **tested all Auth, User, and Child routes**, and all are working correctly. 