### PR TITLE
Add past events toggle to events page

### DIFF
--- a/frontend/src/components/eventsPage/ActivityBlock.tsx
+++ b/frontend/src/components/eventsPage/ActivityBlock.tsx
@@ -15,6 +15,9 @@ interface Props {
   isAdmin: boolean;
   onDeleteEvent: (id: string) => void;
   onDeleteProgram: (id: string) => void;
+  showPastButton?: boolean;
+  showPastEvents?: boolean;
+  onTogglePastEvents?: () => void;
 }
 
 /** Theme per activity (bar, title, chip colors) */
@@ -82,6 +85,9 @@ export default function ActivityBlock({
   isAdmin,
   onDeleteEvent,
   onDeleteProgram,
+  showPastButton,
+  showPastEvents,
+  onTogglePastEvents,
 }: Props) {
   const theme = getTheme(activityName);
 
@@ -146,17 +152,28 @@ export default function ActivityBlock({
     <section className="mb-16">
       {/* --- Minimal header: icon chip + title + thin accent bar --- */}
       <div className="mb-4">
-        <div className="flex items-center gap-3">
-          <span
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
             className={`inline-grid h-12 w-12 place-items-center rounded-xl ring-1 ${theme.chipBg} ${theme.chipRing}`}
             aria-hidden="true"
-          >
-            <HeaderIcon name={activityName} />
-          </span>
+            >
+              <HeaderIcon name={activityName} />
+            </span>
+              <h2 className={`text-2xl md:text-3xl font-bold ${theme.title}`}>
+              {activityName === 'Enrichment Programs' ? 'Programs' : activityName}
+              </h2>
+          </div>
 
-          <h2 className={`text-2xl md:text-3xl font-bold ${theme.title}`}>
-            {activityName === 'Enrichment Programs' ? 'Programs' : activityName}
-          </h2>
+          {showPastButton && (
+            <button
+              type="button"
+              onClick={onTogglePastEvents}
+              className="inline-flex items-center gap-2 rounded-full bg-wondergreen px-5 py-2.5 text-sm font-bold text-white shadow-md hover:bg-wonderleaf hover:shadow-lg transition-all duration-200"
+            >
+              {showPastEvents ? "← Current Events" : "Past Events →"}
+            </button>
+          )}
         </div>
 
         {/* thin bar */}

--- a/frontend/src/components/eventsPage/EventsPageContent.tsx
+++ b/frontend/src/components/eventsPage/EventsPageContent.tsx
@@ -28,6 +28,7 @@ export default function EventsPageContent() {
   const [grouped, setGrouped] = useState<GroupedActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [toast, setToast] = useState<string | null>(null);
+  const [showPastEvents, setShowPastEvents] = useState(false);
 
   useEffect(() => {
     const success = searchParams.get('success');
@@ -55,7 +56,13 @@ export default function EventsPageContent() {
           activityName: activity.name,
           events: (activity.events ?? [])
           .filter((e) => e.status === "approved")
-          .filter((e) => new Date(e.date) >= new Date())
+          .filter((e) => {
+            const eventDate = new Date(e.date);
+            const today = new Date();
+            return showPastEvents
+              ? eventDate < today
+              : eventDate >= today;
+          })
           .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
           programs: programs
           .filter((p) => p.activityId === activity.id)
@@ -90,7 +97,7 @@ export default function EventsPageContent() {
     };
 
     fetchAll();
-  }, []);
+  }, [showPastEvents]);
 
   const handleDeleteEvent = (deletedId: string) => {
     setGrouped(prev =>
@@ -125,7 +132,7 @@ export default function EventsPageContent() {
       )}
       <GradientBanner
         size="md"
-        title="Upcoming Events"
+        title={showPastEvents ? "Past Events" : "Upcoming Events"}
         subtitle="Connect with other homeschooling families through hands-on
           experiences, outdoor adventures, and educational opportunities."
       />
@@ -149,6 +156,9 @@ export default function EventsPageContent() {
             isAdmin={isAdmin}
             onDeleteEvent={handleDeleteEvent}
             onDeleteProgram={handleDeleteProgram}
+            showPastButton={activityName.toLowerCase().includes("event")}
+            showPastEvents={showPastEvents}
+            onTogglePastEvents={() => setShowPastEvents((prev) => !prev)}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Added a **Past Events** toggle to the Events page.
- Users can switch between current and past events.
- The Events section updates based on the selected view.