### PR TITLE
Fix Next.js build failures on / and /fundraiser-dinner

### DIFF
--- a/frontend/src/app/fundraiser-dinner/page.tsx
+++ b/frontend/src/app/fundraiser-dinner/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import FundraiserDinnerPaymentPage from "../../components/fundraiserDinner/FundraiserDinner";
 
 export default function FundraiserDinner() {
@@ -13,7 +14,9 @@ export default function FundraiserDinner() {
                     </p>
                 </div>
                 <div className="flex flex-col items-center justify-center py-8 px-4 sm:px-6 lg:px-8">
-                    <FundraiserDinnerPaymentPage />
+                    <Suspense>
+                        <FundraiserDinnerPaymentPage />
+                    </Suspense>
                 </div>
             </div>
         </>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,31 +1,18 @@
-"use client";
-
+import { Suspense } from "react";
 import HeroSection from "@/components/landing/HeroSection";
 import Story_Mission from "@/components/landing/Story_Mission";
 import ImpactStats from "@/components/landing/ImpactNumbers";
 import OurPrograms from "@/components/landing/OurPrograms"
-import { useEffect, Suspense } from "react";
-import { useSearchParams } from "next/navigation";
-import { useModal } from "@/context/modal";
-import TaxReturnSuccessModal from "@/components/TaxReturn/TaxReturnSuccessModal";
 import HowToJoin from "@/components/landing/HowToJoin";
 import ContactUsSection from "@/components/landing/contactUsSection";
+import TaxReturnModalTrigger from "@/components/landing/TaxReturnModalTrigger";
 
-
-function FunctionLandingPage() {
-  const searchParams = useSearchParams()
-  const modal = searchParams.get("modal")
-  const { setModalContent } = useModal()
-
-  useEffect(() => {
-    if (modal === "taxReturnSuccess") {
-      setModalContent(<TaxReturnSuccessModal />)
-    }
-  }, [modal, setModalContent])
-
-
+export default function LandingPage() {
   return (
     <main>
+      <Suspense fallback={null}>
+        <TaxReturnModalTrigger />
+      </Suspense>
       {/* Top sections of the landing page */}
       <HeroSection />
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -36,14 +23,5 @@ function FunctionLandingPage() {
         <ContactUsSection />
       </div>
     </main>
-  )
-}
-
-export default function LandingPage(){
-  return(
-    <Suspense fallback={null}>
-      <FunctionLandingPage />
-    </Suspense>
-
   )
 }

--- a/frontend/src/components/landing/AnimatedStat.tsx
+++ b/frontend/src/components/landing/AnimatedStat.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import CountUp from "react-countup";
+
+export default function AnimatedStat({ value, suffix, duration }: { value: number; suffix: string; duration: number }) {
+  return <CountUp end={value} duration={duration} suffix={suffix} />;
+}

--- a/frontend/src/components/landing/ImpactNumbers.tsx
+++ b/frontend/src/components/landing/ImpactNumbers.tsx
@@ -1,21 +1,32 @@
-import CountUp from 'react-countup';
+import AnimatedStat from './AnimatedStat';
 import { determineEnv, makeApiRequest } from '../../../utils/api';
 import { User } from '@/types/user';
 const WONDERHOOD_URL = determineEnv()
 
-const families: User[] = await makeApiRequest(`${WONDERHOOD_URL}/user/`);
-const { totalEventsCreated, totalProgramsCreated } = await makeApiRequest<{ totalEventsCreated: number; totalProgramsCreated: number }>(`${WONDERHOOD_URL}/impact/events-programs`);
+async function getImpactData() {
+  try {
+    const [families, { totalEventsCreated, totalProgramsCreated }] = await Promise.all([
+      makeApiRequest<User[]>(`${WONDERHOOD_URL}/user/`),
+      makeApiRequest<{ totalEventsCreated: number; totalProgramsCreated: number }>(`${WONDERHOOD_URL}/impact/events-programs`),
+    ]);
 
+    return { familyCount: families.length, eventsAndPrograms: totalEventsCreated + totalProgramsCreated };
+  } catch {
+    return { familyCount: 0, eventsAndPrograms: 0 };
+  }
+}
 
-const stats = [
-  { value: families.length, suffix: "+", label: "Families Joined" },
-  { value: totalEventsCreated + totalProgramsCreated, suffix: "+", label: "Events & Programs Published" },
-  { value: 100, suffix: "%", label: "Real-World Learning" },
-  { value: 100, suffix: "%", label: "Mission-Driven" },
-  { value: 100, suffix: "%", label: "Community-Focused" },
-];
+export default async function ImpactStats() {
+  const { familyCount, eventsAndPrograms } = await getImpactData();
 
-export default function ImpactStats() {
+  const stats = [
+    { value: familyCount, suffix: "+", label: "Families Joined" },
+    { value: eventsAndPrograms, suffix: "+", label: "Events & Programs Published" },
+    { value: 100, suffix: "%", label: "Real-World Learning" },
+    { value: 100, suffix: "%", label: "Mission-Driven" },
+    { value: 100, suffix: "%", label: "Community-Focused" },
+  ];
+
   return (
     <section className="w-full pt-10 pb-7 text-wondergreen bg-[#FAF7ED] my-8">
       <div className="max-w-7xl mx-auto flex flex-col items-center px-4">
@@ -56,7 +67,7 @@ export default function ImpactStats() {
 
             >
               <span className="text-3xl sm:text-4xl md:text-[38px] xl:text-[40px] font-bold text-wondergreen mt-2">
-                <CountUp end={stat.value} duration={1.4 + idx * 0.2} suffix={stat.suffix} />
+                <AnimatedStat value={stat.value} duration={1.4 + idx * 0.2} suffix={stat.suffix} />
               </span>
               <div className="mt-2 text-center text-orange-400 font-medium">
                 <div className="text-base sm:text-base xl:text-lg whitespace-nowrap">{stat.label}</div>

--- a/frontend/src/components/landing/Story_Mission.tsx
+++ b/frontend/src/components/landing/Story_Mission.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay } from "swiper/modules";

--- a/frontend/src/components/landing/TaxReturnModalTrigger.tsx
+++ b/frontend/src/components/landing/TaxReturnModalTrigger.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { useModal } from "@/context/modal";
+import TaxReturnSuccessModal from "@/components/TaxReturn/TaxReturnSuccessModal";
+
+export default function TaxReturnModalTrigger() {
+  const searchParams = useSearchParams();
+  const modal = searchParams.get("modal");
+  const { setModalContent } = useModal();
+
+  useEffect(() => {
+    if (modal === "taxReturnSuccess") {
+      setModalContent(<TaxReturnSuccessModal />);
+    }
+  }, [modal, setModalContent]);
+
+  return null;
+}


### PR DESCRIPTION
- Wrap useSearchParams() usage in fundraiser-dinner page in <Suspense>, matching the pattern used elsewhere in the app router.
- Convert the homepage to a real Server Component: extract the client-only tax-return modal logic into TaxReturnModalTrigger, and make ImpactStats a proper async Server Component instead of relying on an accidental client-wide boundary.
- Move the top-level await fetches in ImpactNumbers into a try/catch so a build-time backend outage degrades to fallback values instead of crashing the whole build.
- Add "use client" to Story_Mission (uses swiper/react) and split react-countup into a small AnimatedStat client component, since both need a browser environment and previously only worked by riding on the homepage's blanket "use client" directive.